### PR TITLE
Fix Segmentation Fault when used ValueJson function.

### DIFF
--- a/jq.go
+++ b/jq.go
@@ -11,14 +11,15 @@ import (
 )
 
 type JQ struct {
-	program   string
-	state     *C.jq_state
-	lastValue C.jv
+	program    string
+	state      *C.jq_state
+	lastValue  C.jv
+	prevRefCnt int
 }
 
 func NewJQ(program string) (*JQ, error) {
 	state := C.jq_init()
-	jq := &JQ{program, state, C.jv_invalid()}
+	jq := &JQ{program, state, C.jv_invalid(), 0}
 	if err := jq.compile(program); err != nil {
 		jq.Close()
 		return nil, err
@@ -35,9 +36,12 @@ func (jq *JQ) HandleJson(text string) {
 }
 
 func (jq *JQ) Next() bool {
-	// FIXME this raises assertion if called before start()
-	freeJv(jq.lastValue)
+	// jq.ValueJson() is self execute internally (jv_dump_term in the jv_dump_string)
+	if jq.prevRefCnt == jq.jv_get_refcnt() {
+		freeJv(jq.lastValue)
+	}
 	jq.lastValue = jq.next()
+	jq.prevRefCnt = jq.jv_get_refcnt()
 	return isValid(jq.lastValue)
 }
 
@@ -71,6 +75,10 @@ func (jq *JQ) next() C.jv {
 
 func (jq *JQ) teardown() {
 	C.jq_teardown(&jq.state)
+}
+
+func (jq *JQ) jv_get_refcnt() int {
+	return (int)(C.jv_get_refcnt(jq.lastValue))
 }
 
 // JSON values

--- a/jq_test.go
+++ b/jq_test.go
@@ -93,6 +93,25 @@ func TestTransformArrayJson(t *testing.T) {
 	equals(t, false, jq.Next())
 }
 
+func TestTransformArrayJsonString(t *testing.T) {
+	jq, err := NewJQ(".[]")
+	ok(t, err)
+	defer jq.Close()
+
+	jq.HandleJson("[1, 2, 3]")
+
+	equals(t, true, jq.Next())
+	equals(t, "1", jq.ValueJson())
+
+	equals(t, true, jq.Next())
+	equals(t, "2", jq.ValueJson())
+
+	equals(t, true, jq.Next())
+	equals(t, "3", jq.ValueJson())
+
+	equals(t, false, jq.Next())
+}
+
 // TODO KIND_INVALID
 
 func assertJsonParsed(t *testing.T, expected interface{}, json string) {


### PR DESCRIPTION
Hi.

found Segmentation Fault. then ValueJson itself is executing jv_free.
https://github.com/stedolan/jq/blob/master/src/jv_print.c#L335
https://github.com/stedolan/jq/blob/master/src/jv_print.c#L306

check of jv_get_refcnt succeeded. :-)
(jv_get_refcnt is decrement when executed for jv_free)